### PR TITLE
Implement purchase method and fix InvoiceNinja compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,5 @@
         "post-install-cmd": [
             "@git-hook-install"
         ]
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0.0-dev"
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.0-dev",
-            "dev-fix_invoiceninja_compatibility": "1.0.0-dev"
+            "dev-master": "1.0.0-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,11 @@
         "post-install-cmd": [
             "@git-hook-install"
         ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.0-dev",
+            "dev-fix_invoiceninja_compatibility": "1.0.0-dev"
+        }
     }
 }

--- a/src/AbstractGateway.php
+++ b/src/AbstractGateway.php
@@ -49,7 +49,7 @@ abstract class AbstractGateway extends OmnipayAbstractGateway
             'proxyLogin' => '',
             'proxyPassword' => '',
             'contractNumber' => '',
-            'testMode' => true,
+            'testMode' => false,
         );
     }
 
@@ -193,7 +193,7 @@ abstract class AbstractGateway extends OmnipayAbstractGateway
             'connection_timeout' => 5,
         );
 
-        if ($this->getProxyHost()) {
+        if (strlen($this->getProxyHost()) > 1) {
             $header['proxy_host'] = $this->getProxyHost();
             $header['proxy_port'] = $this->getProxyPort();
             $header['proxy_login'] = $this->getProxyLogin();

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -41,11 +41,11 @@ class DirectGateway extends AbstractGateway
     /**
      * @param array $parameters
      *
-     * @return \Omnipay\Payline\Message\Direct\CaptureRequest
+     * @return \Omnipay\Payline\Message\Direct\PurchaseRequest
      */
     public function purchase(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\Payline\Message\Direct\CaptureRequest', $parameters);
+        return $this->createRequest('\Omnipay\Payline\Message\Direct\PurchaseRequest', $parameters);
     }
 
     /**

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -43,6 +43,16 @@ class DirectGateway extends AbstractGateway
      *
      * @return \Omnipay\Payline\Message\Direct\CaptureRequest
      */
+    public function purchase(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Payline\Message\Direct\CaptureRequest', $parameters);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return \Omnipay\Payline\Message\Direct\CaptureRequest
+     */
     public function capture(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\Payline\Message\Direct\CaptureRequest', $parameters);

--- a/src/Message/AbstractResponse.php
+++ b/src/Message/AbstractResponse.php
@@ -44,6 +44,6 @@ abstract class AbstractResponse extends OmnipayAbstractResponse
 
     public function getTransactionReference()
     {
-        return $this->request->getTransactionReference();
+        return $this->data->transaction->id;
     }
 }

--- a/src/Message/AbstractResponse.php
+++ b/src/Message/AbstractResponse.php
@@ -41,4 +41,9 @@ abstract class AbstractResponse extends OmnipayAbstractResponse
     {
         return $this->data->result->longMessage;
     }
+
+    public function getTransactionReference()
+    {
+        return $this->request->getTransactionReference();
+    }
 }

--- a/src/Message/Direct/AuthorizeRequest.php
+++ b/src/Message/Direct/AuthorizeRequest.php
@@ -12,6 +12,7 @@
 namespace Omnipay\Payline\Message\Direct;
 
 use Omnipay\Payline\Message\AbstractRequest;
+use DateTime;
 
 /**
  * AuthorizeRequest.
@@ -89,7 +90,7 @@ class AuthorizeRequest extends AbstractRequest
      */
     public function getDate()
     {
-        return $this->getParameter('date');
+        return $this->getParameter('date') ?: date_create()->format('d/m/Y H:i');
     }
 
     /**
@@ -125,7 +126,7 @@ class AuthorizeRequest extends AbstractRequest
         }
 
         $data['order'] = array(
-            'ref' => $this->getTransactionReference(),
+            'ref' => $this->getTransactionId(),
             'amount' => $this->getAmountInteger(),
             'currency' => $this->getCurrencyNumeric(),
         );
@@ -154,8 +155,7 @@ class AuthorizeRequest extends AbstractRequest
                 'zipCode' => $card->getShippingPostcode(),
                 'state' => $card->getShippingState(),
                 'country' => $card->getShippingCountry(),
-                'phone' => $card->getShippingPhone(),
-                'phoneType' => $card->getShippingPhoneExtension(),
+                'phone' => $card->getShippingPhone()
             ),
             'billingAddress' => array(
                 'title' => $card->getBillingTitle(),
@@ -168,10 +168,16 @@ class AuthorizeRequest extends AbstractRequest
                 'zipCode' => $card->getBillingPostcode(),
                 'state' => $card->getBillingState(),
                 'country' => $card->getBillingCountry(),
-                'phone' => $card->getBillingPhone(),
-                'phoneType' => $card->getBillingPhoneExtension(),
+                'phone' => $card->getBillingPhone()
             ),
         );
+        // Omnipay-common < 2.5 do not have the following methods
+        if ( method_exists($card, 'getShippingPhoneExtension') ) {
+            $data['buyer']['shippingAdress']['phoneType'] =
+                $card->getShippingPhoneExtension();
+            $data['buyer']['billingAddress']['phoneType'] =
+                $card->getBillingPhoneExtension();
+        }
 
         $data['order']['date'] = $this->getDate();
 

--- a/src/Message/Direct/CaptureRequest.php
+++ b/src/Message/Direct/CaptureRequest.php
@@ -33,7 +33,7 @@ class CaptureRequest extends AuthorizeRequest
         $data['payment'] = array(
             'amount' => $this->getAmountInteger(),
             'currency' => $this->getCurrencyNumeric(),
-            'action' => 201,
+            'action' => 101,
             'mode' => $this->getPaymentMethod(),
         );
 

--- a/src/Message/Direct/CaptureRequest.php
+++ b/src/Message/Direct/CaptureRequest.php
@@ -28,7 +28,7 @@ class CaptureRequest extends AuthorizeRequest
 
     public function getData()
     {
-        $data['transactionID'] = $this->getTransactionId();
+        $data['transactionID'] = $this->getTransactionReference();
 
         $data['payment'] = array(
             'amount' => $this->getAmountInteger(),

--- a/src/Message/Direct/CaptureRequest.php
+++ b/src/Message/Direct/CaptureRequest.php
@@ -33,7 +33,7 @@ class CaptureRequest extends AuthorizeRequest
         $data['payment'] = array(
             'amount' => $this->getAmountInteger(),
             'currency' => $this->getCurrencyNumeric(),
-            'action' => 101,
+            'action' => 201,
             'mode' => $this->getPaymentMode() ?: 'CPT',
         );
 

--- a/src/Message/Direct/CaptureRequest.php
+++ b/src/Message/Direct/CaptureRequest.php
@@ -34,7 +34,7 @@ class CaptureRequest extends AuthorizeRequest
             'amount' => $this->getAmountInteger(),
             'currency' => $this->getCurrencyNumeric(),
             'action' => 101,
-            'mode' => $this->getPaymentMethod(),
+            'mode' => $this->getPaymentMode() ?: 'CPT',
         );
 
         if ($this->getContractNumber()) {

--- a/src/Message/Direct/CreditRequest.php
+++ b/src/Message/Direct/CreditRequest.php
@@ -47,7 +47,7 @@ class CreditRequest extends AuthorizeRequest
         }
 
         $data['order'] = array(
-            'ref' => $this->getTransactionReference(),
+            'ref' => $this->getTransactionId(),
             'amount' => $this->getAmountInteger(),
             'currency' => $this->getCurrencyNumeric(),
         );

--- a/src/Message/Direct/PurchaseRequest.php
+++ b/src/Message/Direct/PurchaseRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Payline driver for the Omnipay PHP payment processing library
+ *
+ * @link      https://github.com/ck-developer/omnipay-payline
+ * @package   omnipay-payline
+ * @license   MIT
+ * @copyright Copyright (c) 2016 - 217 Claude Khedhiri <claude@khedhiri.com>
+ */
+
+namespace Omnipay\Payline\Message\Direct;
+
+/**
+ * Purchase Request.
+ */
+class PurchaseRequest extends AuthorizeRequest
+{
+
+    public function getData()
+    {
+        $data = parent::getData();
+        $data['payment']['action'] = 101;
+
+        return $data;
+    }
+}

--- a/src/Message/Direct/RefundRequest.php
+++ b/src/Message/Direct/RefundRequest.php
@@ -35,11 +35,11 @@ class RefundRequest extends AuthorizeRequest
     {
         $data = $this->getBaseData();
 
-        $data['transactionID'] = $this->getTransactionId();
+        $data['transactionID'] = $this->getTransactionReference();
 
         $data['payment'] = array(
             'amount' => $this->getAmountInteger(),
-            'currency' => $this->getCurrencyNumeric(),
+            'currency' => $this->getCurrencyNumeric() ?: 978,
             'action' => 421,
             'mode' => 'CPT',
         );

--- a/src/Message/Web/AuthorizeRequest.php
+++ b/src/Message/Web/AuthorizeRequest.php
@@ -120,7 +120,7 @@ class AuthorizeRequest extends AbstractRequest
         }
 
         $data['order'] = array(
-            'ref' => $this->getTransactionReference(),
+            'ref' => $this->getTransactionId(),
             'amount' => $this->getAmountInteger(),
             'currency' => $this->getCurrencyNumeric(),
         );

--- a/tests/DirectGatewayTest.php
+++ b/tests/DirectGatewayTest.php
@@ -40,7 +40,7 @@ class DirectGatewayTest extends GatewayTestCase
 
         /** @var \Omnipay\Payline\Message\Direct\AuthorizeResponse $response */
         $response = $this->gateway->authorize(array(
-            'transactionReference' => sprintf('ORDER_%s', rand(1, 100)),
+            'transactionId' => sprintf('ORDER_%s', rand(1, 100)),
             'amount' => '33.00',
             'currency' => 'EUR',
             'date' => new \DateTime(),
@@ -56,7 +56,7 @@ class DirectGatewayTest extends GatewayTestCase
 
         /** @var \Omnipay\Payline\Message\Direct\AuthorizeResponse $response */
         $response = $this->gateway->authorize(array(
-            'transactionReference' => sprintf('ORDER_%s', rand(1, 100)),
+            'transactionId' => sprintf('ORDER_%s', rand(1, 100)),
             'amount' => '33.00',
             'currency' => 'EUR',
             'date' => new \DateTime(),
@@ -76,7 +76,7 @@ class DirectGatewayTest extends GatewayTestCase
         $this->mockHttpClientMethodFromFile('doCapture', 'CaptureSuccess');
 
         $response = $this->gateway->capture(array(
-            'transactionId' => '27067232451362',
+            'transactionReference' => '27067232451362',
             'amount' => '33.00',
             'currency' => 'EUR',
             'date' => new \DateTime(),
@@ -96,7 +96,7 @@ class DirectGatewayTest extends GatewayTestCase
         $this->mockHttpClientMethodFromFile('doCapture', 'CaptureFailure');
 
         $response = $this->gateway->capture(array(
-            'transactionId' => '',
+            'transactionReference' => '',
             'amount' => '33.00',
             'currency' => 'EUR',
             'date' => new \DateTime(),
@@ -116,7 +116,7 @@ class DirectGatewayTest extends GatewayTestCase
         $this->mockHttpClientMethodFromFile('doRefund', 'RefundSuccess');
 
         $response = $this->gateway->refund(array(
-            'transactionId' => '27067232451362',
+            'transactionReference' => '27067232451362',
             'amount' => '10.00',
             'currency' => 'EUR',
         ))->send();
@@ -129,7 +129,7 @@ class DirectGatewayTest extends GatewayTestCase
         $this->mockHttpClientMethodFromFile('doRefund', 'RefundFailure');
 
         $response = $this->gateway->refund(array(
-            'transactionId' => '27068165254877',
+            'transactionReference' => '27068165254877',
             'amount' => '10.00',
             'currency' => 'EUR',
         ))->send();

--- a/tests/Message/Direct/AuthorizeRequestTest.php
+++ b/tests/Message/Direct/AuthorizeRequestTest.php
@@ -37,7 +37,7 @@ class AuthorizeRequestTest extends MessageTestCase
     {
         $this->request->initialize(array(
             'contractNumber' => '1234567',
-            'transactionReference' => $ref = sprintf('ORDER_%s', rand(1, 100)),
+            'transactionId' => $ref = sprintf('ORDER_%s', rand(1, 100)),
             'amount' => '300.00',
             'currency' => 'EUR',
             'paymentMode' => 'NX',

--- a/tests/Message/Direct/CreditRequestTest.php
+++ b/tests/Message/Direct/CreditRequestTest.php
@@ -37,7 +37,7 @@ class CreditRequestTest extends MessageTestCase
     {
         $this->request->initialize(array(
             'contractNumber' => '1234567',
-            'transactionReference' => $ref = sprintf('ORDER_%s', rand(1, 100)),
+            'transactionid' => $ref = sprintf('ORDER_%s', rand(1, 100)),
             'amount' => '300.00',
             'currency' => 'EUR',
             'date' => $date = new \DateTime(),

--- a/tests/Message/Web/AuthorizeRequestTest.php
+++ b/tests/Message/Web/AuthorizeRequestTest.php
@@ -37,7 +37,7 @@ class AuthorizeRequestTest extends MessageTestCase
     {
         $this->request->initialize(array(
             'contractNumber' => '1234567',
-            'transactionReference' => $ref = sprintf('ORDER_%s', rand(1, 100)),
+            'transactionId' => $ref = sprintf('ORDER_%s', rand(1, 100)),
             'amount' => '300.00',
             'currency' => 'EUR',
             'paymentMode' => 'NX',


### PR DESCRIPTION
Hi Claude,

Thanks a lot for your work on this gateway. I'm trying to use it with InvoiceNinja and I noticed numerous incompatibilities:
- In InvoiceNinja, the testMode needs to be false by default, otherwise there is no way to disable it. I know this sucks, but there is no trivial way to fix this in InvoiceNinja itself :-/
- All default parameters must be configured with a value. So I've tweaked your code to ignore proxyHost values of a single character. I know that's not very clean either, but again, I can't fix that directly in InvoiceNinja
- A direct AuthorizeRequest doesn't recieve a date parameter. I'm working on a patch for InvoiceNinja, but in the meantime, it could be nice to have a default value for this parameter.
- A direct RefundRequest doesn't receive a currency parameter. I'm also working on a patch and have also provided a default value in the meantime. 'Euro' should suit most users here, as Payline is almost exclusively used in France (and for good reasons).

Also, you appear to mix `transactionId` with `transactionReference`: according to Omnipay's documentation, the `transactionId` is "my internal reference for the transaction", while the `transactionReference` is "Payline's external reference for the transaction". So let's illustrate how those two should be handled:
1. During a `AuthorizeRequest` or `PurchaseRequest`, I send a `ref` to Payline which is my internal reference for the transaction (`transactionId`), `Invoice0007` for example. They'll use it to prevent duplicate transactions.
2. Payline answers with a `transaction->id`, which is their external reference for the transaction. I store this reference as a `transactionReference` for later use, `27067175816178` for example.
3. During a `CaptureRequest` or `RefundRequest`, I send a `transactionID` to Payline, which is their external reference that I stored as a `transactionReference`, `27067175816178` in this example.

I've fixed your code accordingly.

Finally, I've implemented a very straightforward `PurchaseRequest` which is the equivalent of an `AuthorizeRequest` followed by a `CaptureRequest`. This uses an undocumented feature of Payline: you can send a `payment->action` with code `101` to achieve this.